### PR TITLE
Page support with new top nav. links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-[cloud.iO Website](https://cloudio-project.github.io)
+# cloud.iO Website
+
+This is the source code of the cloud.iO webiste available online at http://cloudio.hevs.ch/.
+
+This webiste is based on the [SinglePaged](https://github.com/t413/SinglePaged) theme. It is powered by [Jekyll](http://jekyllrb.com) and hosted on GitHub Pages.
+
+## Jekyll
+
+To run this webiste locally, you will need first to install the Jekyll gem:
+
+```
+$ gem install github-pages
+$ jekyll serve -w
+```
+
+Visit `http://127.0.0.1:4000/` in your browser to see a live locally served preview.
+
+## License
+
+Open sourced under the [MIT license](LICENSE).

--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,8 @@ safe: false
 
 ### site serving configuration ###
 exclude: [CNAME, README.md, .gitignore]
+include: ['_pages']
+
 permalink: / ## disables post output
 timezone: null
 lsi: false
@@ -26,13 +28,10 @@ google_analytics_key: ## put YOUR key here to enable tracking! (blank to disable
 
 ### template colors, used site-wide via css ###
 colors:
-  black:     '#111111'
+  black:     '#000000'
   white:     '#f8f8f8'
-  blue:      '#49a7e9'
-  green:     '#9bcf2f'
-  purple:    '#c869bf'
-  orange:    '#fab125'
-  turquoise: '#0fbfcf'
+  gray:	     '#111111'
+  navactive: '#188ac7'
 
 kramdown:
   auto_ids:  false

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,15 +1,11 @@
 {% if site.google_analytics_key %}
-<script type="text/javascript">
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', '{{ site.google_analytics_key }}']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-
+  ga('create', {{ site.google_analytics_key }}, 'auto');
+  ga('send', 'pageview');
 </script>
 {% endif %}

--- a/_includes/css/main.css
+++ b/_includes/css/main.css
@@ -15,20 +15,18 @@ html { box-sizing: border-box; }
 {% endfor %}
 
 /* ----- per-post colors! ----- */
-{% for node in site.posts %}
-  {% capture id %}{{ node.id | remove:'/' | downcase }}{% endcapture %}
+{% for node in site.pages %}
+  {% capture id %}{{ node.id }}{% endcapture %}
   {% capture bg %}{% if site.colors[node.bg] %}{{ site.colors[node.bg] }}{% else %}{{ node.bg }}{% endif %}{% endcapture %}
   {% capture fg %}{% if site.colors[node.color] %}{{ site.colors[node.color] }}{% else %}{{ node.color }}{% endif %}{% endcapture %}
-  nav .p-{{id}} { border-color: {{ bg }}; }
   #{{id}} { background-color: {{ bg }} !important; color: {{ fg }}; }
   #{{id}} a { color: {{ fg }}; }
   #{{id}} .sectiondivider { color: {{ bg }}; }
 {% endfor %}
 
-#title {
+#home {
   background-image: url('images/title-bg.jpg');
   background-repeat: repeat-x;
-  background-color: #FBFDFE;
 }
 
 /* ----- code, syntax highlighting, etc ----- */
@@ -116,7 +114,7 @@ hr {
 
 /* ----- top menu ----- */
 
-{% assign navborder = 3 %}
+{% assign navborder = 6 %}
 {% assign navborder_active = 6 %}
 
 nav {
@@ -145,7 +143,7 @@ nav ul li {
   line-height:normal;
   letter-spacing:normal;
   text-transform:uppercase;
-  min-width:110px;
+  min-width:130px;
   line-height:40px;
   margin:0;
 }
@@ -161,9 +159,9 @@ nav ul li a, nav ul li a:visited {
 nav ul li a:hover {
   opacity:1
 }
-nav ul li:hover, nav ul li.active {
-  border-top-width: {{navborder_active}}px;
-  padding-top: 0;
+nav ul li.active {
+  border-top-width:{{navborder_active}}px;
+  border-color:{{ site.colors.navactive }};
 }
 
 
@@ -175,8 +173,6 @@ nav ul li:hover, nav ul li.active {
   width:100%;
   min-height:300px;
   padding:210px 0;
-  background:url(img/bgnoise.png);
-  /* generated noise from noisetexturegenerator.com */
 }
 
 .section:first-of-type {

--- a/_includes/footer.md
+++ b/_includes/footer.md
@@ -1,8 +1,1 @@
-
-
-Design by Tim O'Brien [t413.com](http://t413.com/)
-&mdash;
-[SinglePaged theme](https://github.com/t413/SinglePaged)
-&mdash;
-this site is [open source]({{ site.source_link }})
-
+Based on the [SinglePaged theme](https://github.com/t413/SinglePaged) &mdash; cloud.iO is [an open source project]({{ site.source_link }})

--- a/_pages/01-home.md
+++ b/_pages/01-home.md
@@ -1,11 +1,12 @@
 ---
-title: "home"
-bg: #FBFDFE
-color: black
+title: "Home"
+id: home
 style: center
+bg: #ffffff
+color: black
 ---
 
-![cloud.iO Logo]({{ site.url }}/images/cloud.iO Logo.png)
+![cloud.iO Logo]({{ site.url }}images/cloud.iO Logo.png)
 
 ### Scalable open source IoT solution
 

--- a/_pages/02-intro.md
+++ b/_pages/02-intro.md
@@ -1,12 +1,13 @@
 ---
-title: "how it works"
-bg: black
-color: white
+title: "How It Works"
+id: intro
 style: center
+bg: gray
+color: white
 fa-icon: angle-double-down
 ---
 
-![cloud.iO Architecture]({{ site.url }}/images/Architecture.png)
+![cloud.iO Architecture]({{ site.url }}images/Architecture.png)
 
 In the center of cloud.iO is a slightly modified version of the MIT Licensed [RabbitMQ message broker](https://www.rabbitmq.com). 
 The modifications allows cloud.iO to authenticate devices, applications and users and check for the permission of actually posting

--- a/index.html
+++ b/index.html
@@ -6,27 +6,32 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ site.title }}</title>
-	<meta name="keywords" content="{{ site.keywords }}">
-	<meta name="description" content="{{ site.description }}">
+  <meta name="keywords" content="{{ site.keywords }}">
+  <meta name="description" content="{{ site.description }}">
   <link rel="stylesheet" href="combo.css">
   <link href='http://fonts.googleapis.com/css?family=Raleway:400,300,700' rel='stylesheet' type='text/css'>
-  <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
   {% if site.favicon %}<link rel="shortcut icon" href="{{ site.favicon }}" type="image/x-icon">{% endif %}
-	{% if site.touch_icon %}<link rel="apple-touch-icon" href="{{ site.touch_icon }}">{% endif %}
+  {% if site.touch_icon %}<link rel="apple-touch-icon" href="{{ site.touch_icon }}">{% endif %}
 </head>
 <body>
   <div id="main">
 
-    <nav><ul>
-      {% for node in site.posts reversed %}
-        {% capture id %}{{ node.id | remove:'/' | downcase }}{% endcapture %}
-        <li class="p-{{id}}"><a href="#{{id}}">{{node.title}}</a></li>
+    {% assign sorted_pages = (site.pages | sort: 'title') %}
+    <nav>
+      <ul>
+      {% for page in sorted_pages %}
+        {% if page.title.size > 0 %}
+        {% capture id %}{{ page.id }}{% endcapture %}
+        <li class="p-{{id}}"><a href="#{{id}}">{{page.title}}</a></li>
+        {% endif %}
       {% endfor %}
-    </ul></nav>
+      </ul>
+    </nav>
 
-
-    {% for page in site.posts reversed %}
-      {% capture id %}{{ page.id | remove:'/' | downcase }}{% endcapture %}
+    {% for page in sorted_pages %}
+      {% if page.title.size > 0 %}
+      {% capture id %}{{ page.id }}{% endcapture %}
       <div id="{{id}}" class="section p-{{id}}">
         {% if page.icon %}
         <div class="subtlecircle sectiondivider imaged">
@@ -46,6 +51,7 @@
           {{ page.content }}
         </div>
       </div>
+      {% endif %}
     {% endfor %}
 
 
@@ -56,9 +62,8 @@
       </div>
     </div>
   </div>
-
-{% include analytics.html %}
+  {% include analytics.html %}
 </body>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
 <script src="site.js"></script>
 </html>

--- a/site.js
+++ b/site.js
@@ -53,6 +53,8 @@ $.extend($.easing,
                 }
             }
         });
+
+        activateNav('home');
     };
 
     function populateDestinations() {
@@ -67,6 +69,7 @@ $.extend($.easing,
         for (nav in navs) { $(navs[nav]).removeClass('active'); }
         $(navs[navID]).addClass('active');
     }
+
 })( jQuery );
 
 
@@ -91,11 +94,11 @@ $(document).ready(function (){
         }
 	});
 
-    function animateTitleBackground() {
-        $('#title').css({'background-position-x': '0px'});
-        $('#title').animate({'background-position-x': '800px'}, 40000, 'linear', animateTitleBackground);
+    function animateHomeBackground() {
+        $('#home').css({'background-position-x': '0px'});
+        $('#home').animate({'background-position-x': '800px'}, 40000, 'linear', animateHomeBackground);
     }
 
-    animateTitleBackground();
+    animateHomeBackground(); // Magic
 });
 


### PR DESCRIPTION
I made some improvement of the website:
- Static pages are now displayed instead of posts
- Minimalist footer updated
- The page currently displayed is shown with a different color in the top navigation menu
  ![top-nav-links](https://cloud.githubusercontent.com/assets/229670/11457513/5b268d36-96ab-11e5-8f42-7c8d92314fa2.png)
- Added a Readme file with some instructions on how to serve the website locally. I tested this PR locally, so everything should works fine on Github pages.

It would be great to change the colors of the architecture image to make ti more readable.
